### PR TITLE
Removed check that was causing query_all to crash out

### DIFF
--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -184,7 +184,6 @@ defmodule Forcex do
   def handle_call({:query_all, query, opts = %{page_until_complete: false}}, _from, state = %{access_token: _token, token_type: _token_type}) do
     params = %{"q" => query} |> URI.encode_query
     if Map.get(opts, :warn_on_table_scan, false) == true, do: warn_on_table_scan({:queryAll, query}, state)
-    if opts.warn_on_table_scan == true, do: warn_on_table_scan({:queryAll, query}, state)
     results = authenticated_get("queryAll", "?" <> params, state)
     {:reply, results, state}
   end


### PR DESCRIPTION
Had an issue with calls to query_all failing. It appears that a line of code was left over from a previous change. Removed this check that is no longer needed as the line above handles this situation now. 