### PR TITLE
Create arbitrary SObjects from Map

### DIFF
--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -6,8 +6,9 @@ defmodule Forcex do
   @user_agent [{"User-agent", "forcex"}]
   @accept [{"Accept", "application/json"}]
   @accept_encoding [{"Accept-Encoding", "gzip,deflate"}]
+  @content_type [{"Content-Type", "application/json; charset=UTF-8"}]
 
-  def process_request_headers(headers), do: headers ++ @user_agent ++ @accept ++ @accept_encoding
+  def process_request_headers(headers), do: headers ++ @user_agent ++ @accept ++ @accept_encoding ++ @content_type
 
   def process_headers(headers), do: Map.new(headers)
 

--- a/lib/forcex/client.ex
+++ b/lib/forcex/client.ex
@@ -49,17 +49,18 @@ defmodule Forcex.Client do
   end
 
   def login(conf, starting_struct) do
-    login_payload =
-      conf
-      |> Map.put(:password, "#{conf.password}#{conf.security_token}")
-      |> Map.put(:grant_type, "password")
+    login_payload = conf 
+    |> Map.merge(%{
+      password:   "#{conf.password}#{conf.security_token}",
+      grant_type: "password"
+    })
+
     Forcex.post("/services/oauth2/token?#{URI.encode_query(login_payload)}", starting_struct)
     |> handle_login_response
   end
 
   def locate_services(client) do
-    services = Forcex.services(client)
-    %{client | services: services}
+    %{client | services: Forcex.services(client)}
   end
   
   def create_sobject(client \\ %__MODULE__{}, name \\ "SOBject", map \\ %{})

--- a/lib/forcex/client.ex
+++ b/lib/forcex/client.ex
@@ -61,6 +61,20 @@ defmodule Forcex.Client do
     services = Forcex.services(client)
     %{client | services: services}
   end
+  
+  def create_sobject(client \\ %__MODULE__{}, name \\ "SOBject", map \\ %{})
+
+  def create_sobject(client, name, map) when is_atom(name) do
+    name = name 
+    |> Atom.to_string
+    |> String.capitalize
+
+    client
+    |> create_sobject(name, map)
+  end
+  def create_sobject(client, name, map) do
+    Forcex.post("/services/data/v20.0/sobjects/#{name}", map, client)
+  end
 
   defp handle_login_response(%{"access_token" => token, "token_type" => token_type, "instance_url" => endpoint}) do
     %__MODULE__{access_token: token, token_type: token_type, endpoint: endpoint}


### PR DESCRIPTION
Enables commands such as:

``` elixir
resp = Forcex.post("/services/data/v20.0/sobjects/Case/", %{ "Subject" => "API TEST 2", "Priority" => "High", "Origin" => "Web"}, client)
```

Looking to also implement a helper function for creating SObjects using Forcex.Client. Any thoughts or input?
