### PR TITLE
Temporarily remove Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ otp_release:
 env:
   - MIX_ENV=test
 script:
-  - "mix do deps.get, compile, coveralls.travis"
+  - "mix do deps.get, compile"


### PR DESCRIPTION
This commit removes the build step to run Coveralls during the Travis CI
build.  This is pursuant to a [known bug with
Coveralls](https://github.com/parroty/excoveralls/issues/60).  It
appears to be related to the most recent version of Erlang (OTP 19).

By removing this step in the build process, the Forcex library should be
able to build normally on GitHub Travis CI for now.  Once the bug has
been resolved, Coveralls should be re-enabled.