### PR TITLE
Materialize sobjects

### DIFF
--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -5,6 +5,7 @@ defmodule Forcex do
   @user_agent [{"User-agent", "forcex"}]
   @accept [{"Accept", "application/json"}]
   @accept_encoding [{"Accept-Encoding", "gzip,deflate"}]
+  @content_type [{"Content-Type", "application/json"}]
 
   @type client :: map
   @type response :: map | {number, any}
@@ -44,7 +45,7 @@ defmodule Forcex do
 
   @spec json_request(method, String.t, map | String.t, list, list) :: response
   def json_request(method, url, body, headers, options) do
-    raw_request(method, url, Poison.encode!(body), headers, options)
+    raw_request(method, url, Poison.encode!(body), headers ++ @content_type, options)
   end
 
   @spec raw_request(method, String.t, map | String.t, list, list) :: response

--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -35,7 +35,7 @@ defmodule Forcex do
     %{resp | body: Poison.decode!(body, keys: :atoms), headers: Map.drop(headers, ["Content-Type"])}
     |> process_response
   end
-  def process_response(%HTTPoison.Response{body: body, status_code: 200}), do: body
+  def process_response(%HTTPoison.Response{body: body, status_code: status}) when status in [200, 201, 204], do: body
   def process_response(%HTTPoison.Response{body: body, status_code: status}), do: {status, body}
 
   @spec extra_options :: list


### PR DESCRIPTION
Allow for easier transactional interaction with SFDC by supporting dynamic creation of CRUD modules for each standard object accessible by the provided client.

To dynamically create the modules, call `materialize_sobjects/1` on the initialized client:

```elixir
client = Forcex.Client.login |> Forcex.Client.locate_services
Forcex.materialize_sobjects(client)
```

Example usage:
```elixir
Forcex.Account.create(%{name: "Anna", custom_field__c: "no one else does this", external_unique_identifier__c: "abcd"}, client) 
# -> "1234"
Forcex.Account.get_by_id("1234", client)
# -> %{id: "1234", name: "Anna", ...}
Forcex.Account.get_by_external_id("External_Unique_Identifier__c", "abcd", client)
# -> %{id: "1234", name: "Anna", ...}
Forcex.Account.update("1234", %{name: "Banana"}, client)
# -> ""
Forcex.Account.delete("1234", client)
# -> ""
```