### PR TITLE
Configure debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ config :forcex, Forcex.Client,
   password: "my_super_secret_password",
   security_token: "EMAILED_FROM_SALESFORCE",
   client_id: "CONNECTED_APP_OAUTH_CLIENT_ID",
-  client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET"
+  client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET",
+  debug: true
 ```
 
 or these environment variables:
@@ -86,6 +87,7 @@ or these environment variables:
 * `SALESFORCE_SECURITY_TOKEN`
 * `SALESFORCE_CLIENT_ID`
 * `SALESFORCE_CLIENT_SECRET`
+* `SALESFORCE_DEBUG`
 
 HTTPoison request-specific options may also be configured:
 

--- a/lib/forcex/client.ex
+++ b/lib/forcex/client.ex
@@ -18,7 +18,8 @@ defmodule Forcex.Client do
         password: "...",
         security_token: "...",
         client_id: "...",
-        client_secret: "..."
+        client_secret: "...",
+        debug: true
       }
 
   Environment variables
@@ -27,6 +28,7 @@ defmodule Forcex.Client do
     - `SALESFORCE_SECURITY_TOKEN`
     - `SALESFORCE_CLIENT_ID`
     - `SALESFORCE_CLIENT_SECRET`
+    - `SALESFORCE_DEBUG`
 
   Application configuration
 
@@ -35,7 +37,8 @@ defmodule Forcex.Client do
         password: "my_super_secret_password",
         security_token: "EMAILED_FROM_SALESFORCE",
         client_id: "CONNECTED_APP_OAUTH_CLIENT_ID",
-        client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET"
+        client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET",
+        debug: true
 
   Will require additional call to `locate_services/1` to identify which Force.com
   services are availabe for your deployment.
@@ -60,7 +63,7 @@ defmodule Forcex.Client do
   def locate_services(client) do
     services = Forcex.services(client)
     %{client | services: services}
-    |> IO.inspect
+    |> debug
   end
 
   defp handle_login_response(%{access_token: token, token_type: token_type, instance_url: endpoint}) do
@@ -75,6 +78,18 @@ defmodule Forcex.Client do
     [:username, :password, :security_token, :client_id, :client_secret]
     |> Enum.map(&( {&1, get_val_from_env(&1)}))
     |> Enum.into(%{})
+  end
+
+  defp debug(client) do
+    case get_val_from_env(:debug) do
+      true ->
+        IO.inspect(client)
+        client
+      "true" ->
+        IO.inspect(client)
+        client
+      _ -> client
+    end
   end
 
   defp get_val_from_env(key) do


### PR DESCRIPTION
Showing debugging not by default, but when Forcex has been configured to do so. This avoids a noisy output by default.