### PR TITLE
Extend configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ config :forcex, Forcex.Client,
   password: "my_super_secret_password",
   security_token: "EMAILED_FROM_SALESFORCE",
   client_id: "CONNECTED_APP_OAUTH_CLIENT_ID",
-  client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET"
+  client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET",
+  endpoint: "https://test.salesforce.com",
+  modules: ["People"]
 ```
 
 or these environment variables:
@@ -86,6 +88,8 @@ or these environment variables:
 * `SALESFORCE_SECURITY_TOKEN`
 * `SALESFORCE_CLIENT_ID`
 * `SALESFORCE_CLIENT_SECRET`
+
+The endpoint (defaults to `https://login.salesforce.com`) and modules configurations are optional. The list of modules can be specified so that only particular Salesforce Objects are compiled instead of compiling entire Salesforce object. 
 
 HTTPoison request-specific options may also be configured:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ or these environment variables:
 * `SALESFORCE_CLIENT_ID`
 * `SALESFORCE_CLIENT_SECRET`
 
-The endpoint (defaults to `https://login.salesforce.com`) and modules configurations are optional. The list of modules can be specified so that only particular Salesforce Objects are compiled instead of compiling entire Salesforce object. 
+The endpoint (defaults to `https://login.salesforce.com`) and modules configurations are optional. The list of modules can be specified so that only particular Salesforce Objects are compiled instead of compiling entire available Salesforce objects. 
 
 HTTPoison request-specific options may also be configured:
 

--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -5,7 +5,7 @@ defmodule Forcex do
   @user_agent [{"User-agent", "forcex"}]
   @accept [{"Accept", "application/json"}]
   @accept_encoding [{"Accept-Encoding", "gzip,deflate"}]
-  @content_type [{"Content-Type", "application/json"}]
+  @content_type [{"Content-Type", "application/json; charset=utf-8"}]
 
   @type client :: map
   @type response :: map | {number, any}

--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -35,7 +35,7 @@ defmodule Forcex do
     %{resp | body: Poison.decode!(body, keys: :atoms), headers: Map.drop(headers, ["Content-Type"])}
     |> process_response
   end
-  def process_response(%HTTPoison.Response{body: body, status_code: 200}), do: body
+  def process_response(%HTTPoison.Response{body: body, status_code: status}) when status in [200, 201, 204], do: body
   def process_response(%HTTPoison.Response{body: body, status_code: status}), do: {status, body}
 
   @spec extra_options :: list

--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -5,13 +5,14 @@ defmodule Forcex do
   @user_agent [{"User-agent", "forcex"}]
   @accept [{"Accept", "application/json"}]
   @accept_encoding [{"Accept-Encoding", "gzip,deflate"}]
+  @content_type [{"Content-Type", "application/json"}]
 
   @type client :: map
   @type response :: map | {number, any}
   @type method :: :get | :put | :post | :patch | :delete
 
   @spec process_request_headers(list({String.t, String.t})) :: list({String.t, String.t})
-  def process_request_headers(headers), do: headers ++ @user_agent ++ @accept ++ @accept_encoding
+  def process_request_headers(headers), do: headers ++ @user_agent ++ @accept ++ @accept_encoding ++ @content_type
 
   @spec process_headers(list({String.t, String.t})) :: map
   def process_headers(headers), do: Map.new(headers)

--- a/lib/mix/tasks/compile.forcex.ex
+++ b/lib/mix/tasks/compile.forcex.ex
@@ -2,11 +2,13 @@ defmodule Mix.Tasks.Compile.Forcex do
   use Mix.Task
 
   @recursive false
+  @default_endpoint "https://login.salesforce.com"
 
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:forcex)
 
-    client = Forcex.Client.login
+    client = Forcex.Client.default_config
+      |> Forcex.Client.login(%Forcex.Client{endpoint: config[:endpoint] || @default_endpoint})
 
     case client do
       %{access_token: nil} -> IO.puts("Invalid configuration/credentials. Cannot generate SObjects.")
@@ -21,6 +23,7 @@ defmodule Mix.Tasks.Compile.Forcex do
       client
       |> Forcex.describe_global
       |> Map.get(:sobjects)
+      |> filter_modules
 
     for sobject <- sobjects do
       sobject
@@ -28,6 +31,18 @@ defmodule Mix.Tasks.Compile.Forcex do
       |> Code.compile_quoted
     end
 
+  end
+
+  defp filter_modules(sobjects) do
+    case config[:modules] |> is_list do
+      true ->
+        sobjects
+        |> Enum.filter(fn sobject ->
+          Map.get(sobject, "name", nil) in config[:modules]
+        end)
+      false ->
+        sobjects
+    end
   end
 
   defp generate_module(sobject, client) do
@@ -215,4 +230,6 @@ defmodule Mix.Tasks.Compile.Forcex do
 "     * `#{value}`\n"
   end
   defp docs_for_picklist_values(_), do: ""
+
+  defp config, do: Application.get_env(:forcex, Forcex.Client)
 end


### PR DESCRIPTION
Hi Jeff!

This pull request captures some prior work done by @gchronis and @techgaun in separate forks.  The main changes are as follows:

* Specifies use of the `UTF-8` charset on `POST` requests
* Handles additional HTTP response codes from SFDC
* Introduces minor updates to the `README` file
* Adds ability to override the default SFDC endpoint when compiling the application

I'm happy to hear your thoughts on these changes.  I must admit, I haven't directly tested these changes, though I'm reasonably sure it should work without issue.  😁

Thanks for your help!