### PR TITLE
Fix compilation warning

### DIFF
--- a/lib/mix/tasks/compile.forcex.ex
+++ b/lib/mix/tasks/compile.forcex.ex
@@ -12,6 +12,8 @@ defmodule Mix.Tasks.Compile.Forcex do
       %{access_token: nil} -> IO.puts("Invalid configuration/credentials. Cannot generate SObjects.")
       _ -> generate_modules(client)
     end
+
+    :ok
   end
 
   defp generate_modules(client) do


### PR DESCRIPTION
Prior to this commit, applications that relied on `forcex` would see a
compiler warning when creating the Salesforce objects.  The return value
of the `run` method provided an array of modules created during the
compilation step.  As per the `Mix.Tasks` spec, this is not a valid
return value.

This commit returns a value of `:ok`, thereby resolving the warning
provided by the compiler.  Developers relying on the library will no
longer see the list of compiled modules in a warning message, as the
compilation will now complete normally.