### PR TITLE
Add ability to override default endpoint at login

### DIFF
--- a/lib/forcex/auth/oauth.ex
+++ b/lib/forcex/auth/oauth.ex
@@ -10,6 +10,7 @@ defmodule Forcex.Auth.OAuth do
       conf
       |> Map.put(:password, "#{conf.password}#{conf.security_token}")
       |> Map.put(:grant_type, "password")
+      |> Map.delete(:endpoint)
 
     "/services/oauth2/token?#{URI.encode_query(login_payload)}"
     |> Forcex.post(starting_struct)

--- a/lib/forcex/client.ex
+++ b/lib/forcex/client.ex
@@ -1,10 +1,12 @@
 defmodule Forcex.Client do
+  require Logger
+
+  @default_endpoint "https://login.salesforce.com"
+
   defstruct api_version: "41.0",
             authorization_header: [],
-            endpoint: "https://login.salesforce.com",
+            endpoint: @default_endpoint,
             services: %{}
-
-  require Logger
 
   @moduledoc """
   This client delegates login to the appropriate endpoint depending on the
@@ -27,7 +29,8 @@ defmodule Forcex.Client do
         password: "...",
         security_token: "...",
         client_id: "...",
-        client_secret: "..."
+        client_secret: "...",
+        endpoint: "..."
       }
 
   Environment variables
@@ -36,6 +39,7 @@ defmodule Forcex.Client do
     - `SALESFORCE_SECURITY_TOKEN`
     - `SALESFORCE_CLIENT_ID`
     - `SALESFORCE_CLIENT_SECRET`
+    - `SALESFORCE_ENDPOINT`
 
   Application configuration
 
@@ -44,7 +48,8 @@ defmodule Forcex.Client do
         password: "my_super_secret_password",
         security_token: "EMAILED_FROM_SALESFORCE",
         client_id: "CONNECTED_APP_OAUTH_CLIENT_ID",
-        client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET"
+        client_secret: "CONNECTED_APP_OAUTH_CLIENT_SECRET",
+        endpoint: "login.salesforce.com"
 
   If no `client_id` is passed login via session id will be attempted with
   `security_token`.
@@ -56,8 +61,8 @@ defmodule Forcex.Client do
         Forcex.Client.login
         |> Forcex.Client.locate_services
   """
-  def login(c \\ default_config()) do
-    login(c, %__MODULE__{})
+  def login(config \\ default_config()) do
+    login(config, %__MODULE__{endpoint: config[:endpoint] || @default_endpoint})
   end
 
   def login(conf, starting_struct) do
@@ -76,7 +81,7 @@ defmodule Forcex.Client do
   end
 
   def default_config() do
-    [:username, :password, :security_token, :client_id, :client_secret]
+    [:username, :password, :security_token, :client_id, :client_secret, :endpoint]
     |> Enum.map(&({&1, get_val_from_env(&1)}))
     |> Enum.filter(fn {_, v} -> v end)
     |> Enum.into(%{})


### PR DESCRIPTION
Prior to this commit, it was not possible to provide an alternative URL
to `Forcex` when logging in.  As a result, non-production builds of
applications that depend on `Forcex` could not point to non-production
regions of Salesforce.

This commit introduces a few key changes to the client configuration and
login process:

1.  The configuration provided to the `:login` method will now be
examined for an endpoint override value.  If no endpoint is provided in
the config, it will default to `https://login.salesforce.com`

2.  If no endpoint config is provided directly, the default
configuration will examine the system environment for an endpoint
variable, as it currently does for username, password, etc.

In addition to allowing developers to provide an alternate login
endpoint during routine use of the library, it will also provide an
opportunity for the compilation process to reference an alternate
endpoint when gathering Salesforce object definitions.
