### PR TITLE
Add SObject Filtering

### DIFF
--- a/lib/mix/tasks/compile.forcex.ex
+++ b/lib/mix/tasks/compile.forcex.ex
@@ -23,6 +23,7 @@ defmodule Mix.Tasks.Compile.Forcex do
       client
       |> Forcex.describe_global
       |> Map.get(:sobjects)
+      |> filter_sobjects
 
     for sobject <- sobjects do
       sobject
@@ -31,6 +32,13 @@ defmodule Mix.Tasks.Compile.Forcex do
     end
 
   end
+
+  defp filter_sobjects(all_sobjects),                    do: filter_sobjects(all_sobjects, config()[:sobjects])
+  defp filter_sobjects(all_sobjects, []),                do: all_sobjects
+  defp filter_sobjects(all_sobjects, nil),               do: all_sobjects
+  defp filter_sobjects(all_sobjects, selected_sobjects), do: Enum.filter(all_sobjects, &sobject_selected?(&1, selected_sobjects))
+
+  defp sobject_selected?(sobject, selected_sobjects), do: sobject.name in selected_sobjects
 
   defp generate_module(sobject, client) do
     name = sobject.name
@@ -217,4 +225,6 @@ defmodule Mix.Tasks.Compile.Forcex do
 "     * `#{value}`\n"
   end
   defp docs_for_picklist_values(_), do: ""
+
+  defp config, do: Application.get_env(:forcex, Forcex.Client)
 end


### PR DESCRIPTION
Prior to this commit, all SObjects returned from the Salesforce API were
generated during compilation.

This commit introduces the ability to filter out only the SObjects
specified by the application using `forcex`.  With this change,
developers will experience shorter compilation times and reduced
complexity when using the `forcex` library.

Note: If the `sobjects` attribute is not provided as part
of the `:forcex, Forcex.Client` configuration, it will default to the
original behavior (i.e. compile all available SObject modules).
Additionally, the filter entries must match the `name` attribute on the
SObject map returned from Salesforce (e.g. Account, Contact, etc.).