### PR TITLE
HTML encode SOAP login info

### DIFF
--- a/lib/forcex/auth/session_id.ex
+++ b/lib/forcex/auth/session_id.ex
@@ -12,6 +12,10 @@ defmodule Forcex.Auth.SessionId do
     schema_instance = "http://www.w3.org/2001/XMLSchema-instance"
     env = "http://schemas.xmlsoap.org/soap/envelope/"
 
+    # Encode otherwise response comes back with error like
+    # UNKNOWN_EXCEPTION: The reference to entity &quot;v4Hq&quot; must end with the &apos;;&apos; delimiter.
+    conf = for {key, val} <- conf, into: %{}, do: {key, HtmlEntities.encode(val)}
+
     body = """
     <?xml version="1.0" encoding="utf-8" ?>
     <env:Envelope xmlns:xsd="#{schema}" xmlns:xsi="#{schema_instance}" xmlns:env="#{env}">
@@ -29,7 +33,7 @@ defmodule Forcex.Auth.SessionId do
       {"SOAPAction", "login"}
     ]
 
-    url = "https://login.salesforce.com/services/Soap/u/#{starting_struct.api_version}"
+    url = starting_struct.endpoint <> "/services/Soap/u/#{starting_struct.api_version}"
 
     Logger.debug("api=#{@api}")
     @api.raw_request(:post, url, body, headers, [])

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,8 @@ defmodule Forcex.Mixfile do
       {:earmark, "~> 1.1", only: :dev, override: true},
       {:dialyxir, "~> 0.4", only: :dev},
       {:mox, "~> 0.3", only: :test},
-      {:mix_test_watch, "~> 0.5", only: [:dev, :test], runtime: false}
+      {:mix_test_watch, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:html_entities, "~> 0.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,7 @@
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.10.1", "c38d0ca52ea80254936a32c45bb7eb414e7a96a521b4ce76d00a69753b157f21", [], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [], [], "hexpm"},


### PR DESCRIPTION
Encode otherwise response comes back with error like

    UNKNOWN_EXCEPTION: The reference to entity &quot;v4Hq&quot; must end with the &apos;;&apos; delimiter.