### PR TITLE
Fix a warning about triple quote string indentation

### DIFF
--- a/lib/forcex/bulk/client.ex
+++ b/lib/forcex/bulk/client.ex
@@ -41,15 +41,15 @@ defmodule Forcex.Bulk.Client do
   end
   def login(conf, starting_struct) do
     envelope = """
-<?xml version="1.0" encoding="utf-8" ?>
-<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
-  <env:Body>
-    <n1:login xmlns:n1="urn:partner.soap.sforce.com">
-      <n1:username>#{conf.username}</n1:username>
-      <n1:password>#{conf.password}#{conf.security_token}</n1:password>
-    </n1:login>
-  </env:Body>
-</env:Envelope>
+    <?xml version="1.0" encoding="utf-8" ?>
+    <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Body>
+        <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+          <n1:username>#{conf.username}</n1:username>
+          <n1:password>#{conf.password}#{conf.security_token}</n1:password>
+        </n1:login>
+      </env:Body>
+    </env:Envelope>
     """
     headers = [
       {"Content-Type", "text/xml; charset=UTF-8"},

--- a/test/forcex/client_test.exs
+++ b/test/forcex/client_test.exs
@@ -39,14 +39,14 @@ defmodule Forcex.ClientTest do
         username: "<<probablynotvalid>>@example.com"
       }
 
-      encoded_config = for {key, val} <- config, into: %{}, do: {key, HtmlEntities.encode(val)}
+      _encoded_config = for {key, val} <- config, into: %{}, do: {key, HtmlEntities.encode(val)}
 
       expected_body = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<env:Envelope xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">\n<env:Body>\n<n1:login xmlns:n1=\"urn:partner.soap.sforce.com\">\n  <n1:username>&lt;&lt;probablynotvalid&gt;&gt;@example.com</n1:username>\n  <n1:password>amper&amp;andflash!</n1:password>\n</n1:login>\n</env:Body>\n</env:Envelope>\n"
 
       Forcex.Api.MockHttp
       |> expect(:raw_request, fn :post, _, ^expected_body, _, _ -> @response end)
 
-      client = Forcex.Client.login(config)
+      _client = Forcex.Client.login(config)
     end
   end
 


### PR DESCRIPTION
Fix a couple warnings about unused variables in tests.

This is super minor and feel free to ignore. This just fixes a warning about string indentation for triple quoted strings. Yes, I'm just being picky. :)
