### PR TITLE
A few updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Tests can be run automatically when files change with
 Tests mock the api calls to the Salesforce API using Mox to set expectations on
 `Forcex.Api.MockHttp.raw_request`.  To know what to put in a mock response just
 run the client in `iex` and look for the debug logging response from http.ex.
-Make sure not to scrub any responses for sensitive data before including them
+Make sure to scrub any responses for sensitive data before including them
 in a commit.
 
 Example assuming environment variables are in place with login info

--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -13,7 +13,7 @@ defmodule Forcex do
 
   @spec json_request(method, String.t, map | String.t, list, list) :: response
   def json_request(method, url, body, headers, options) do
-    @api.raw_request(method, url, Poison.encode!(body), headers, options)
+    @api.raw_request(method, url, format_body(body), headers, options)
   end
 
   @spec post(String.t, map | String.t, client) :: response
@@ -113,4 +113,7 @@ defmodule Forcex do
   defp service_endpoint(%Forcex.Client{services: services}, service) do
     Map.get(services, service)
   end
+
+  defp format_body(""), do: ""
+  defp format_body(body), do: Poison.encode!(body)
 end

--- a/lib/forcex.ex
+++ b/lib/forcex.ex
@@ -19,13 +19,15 @@ defmodule Forcex do
   @spec post(String.t, map | String.t, client) :: response
   def post(path, body \\ "", client) do
     url = client.endpoint <> path
-    json_request(:post, url, body, client.authorization_header, [])
+    headers = [{"Content-Type", "application/json"}]
+    json_request(:post, url, body, headers ++ client.authorization_header, [])
   end
 
   @spec patch(String.t, String.t, client) :: response
   def patch(path, body \\ "", client) do
     url = client.endpoint <> path
-    json_request(:patch, url, body, client.authorization_header, [])
+    headers = [{"Content-Type", "application/json"}]
+    json_request(:patch, url, body, headers ++ client.authorization_header, [])
   end
 
   @spec delete(String.t, client) :: response
@@ -89,6 +91,12 @@ defmodule Forcex do
 
     "#{base}/#{sobject}/describe/"
     |> get("", [{"If-Modified-Since", since}], client)
+  end
+
+  @spec composite_query(map, client) :: response
+  def composite_query(body, %Forcex.Client{} = client) do
+    service_endpoint(client, :composite)
+    |> post(body, client)
   end
 
   @spec query(String.t, client) :: response

--- a/lib/forcex/bulk/client.ex
+++ b/lib/forcex/bulk/client.ex
@@ -41,15 +41,15 @@ defmodule Forcex.Bulk.Client do
   end
   def login(conf, starting_struct) do
     envelope = """
-<?xml version="1.0" encoding="utf-8" ?>
-<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
-  <env:Body>
-    <n1:login xmlns:n1="urn:partner.soap.sforce.com">
-      <n1:username>#{conf.username}</n1:username>
-      <n1:password>#{conf.password}#{conf.security_token}</n1:password>
-    </n1:login>
-  </env:Body>
-</env:Envelope>
+    <?xml version="1.0" encoding="utf-8" ?>
+    <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Body>
+        <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+          <n1:username>#{conf.username}</n1:username>
+          <n1:password>#{conf.password}#{conf.security_token}</n1:password>
+        </n1:login>
+      </env:Body>
+    </env:Envelope>
     """
     headers = [
       {"Content-Type", "text/xml; charset=UTF-8"},


### PR DESCRIPTION
I lumped these together in one PR since they're pretty small; I'm happy to put up multiple PRs if preferable.

- Add composite queries
- Send truly empty bodies when empty
- add `application/json` content-type header for post & patch requests - necessary for json requests, but is it this solution too rigid?
- Fix typo in Readme

fixes #33 