### PR TITLE
Update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ client = Forcex.Client.login |> Forcex.Client.locate_services
 
 first_page = Forcex.query("select Id, Name from Account order by CreatedDate desc", client)
 
-second_page = first_page |> Map.get("nextRecordsUrl") |> Forcex.get(client)
+second_page = first_page |> Map.get(:nextRecordsUrl) |> Forcex.get(client)
 ```
 
 ## Further Configuration


### PR DESCRIPTION
It seems that `first_page` data structure contains the key `:nextRecordsUrl` and not `"nextRecordsUrl"`

Paired with @afbreilyn on this.